### PR TITLE
Add Promise API

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,19 @@ lib.yourUsername.hostStatus({name: 'Dolores Abernathy'}, (err, result) => {
 });
 ```
 
+Or, using the Promise API:
+
+```javascript
+const lib = require('lib');
+lib.yourUsername.hostStatus({name: 'Dolores Abernathy'})
+  .then((result) => {
+    // handle result
+  })
+  .catch((err) => {
+    // handle errors
+  });
+```
+
 To discover StdLib services, visit https://stdlib.com/search. To build a service,
 get started with [the StdLib CLI tools](https://github.com/stdlib/lib).
 

--- a/lib.js
+++ b/lib.js
@@ -23,9 +23,9 @@ module.exports = (function() {
         } else {
           let p = parseParameters(args);
           if (isLocal) {
-            executeLocal(cfg, names, p.args, p.kwargs, p.body, p.callback);
+            return executeLocal(cfg, names, p.args, p.kwargs, p.body, p.callback);
           } else {
-            executeRemote(cfg, names, p.args, p.kwargs, p.body, p.callback);
+            return executeRemote(cfg, names, p.args, p.kwargs, p.body, p.callback);
           }
         }
 

--- a/lib/local.js
+++ b/lib/local.js
@@ -2,59 +2,68 @@ const path = require('path');
 
 module.exports = (cfg, names, args, kwargs, body, callback) => {
 
-  try {
-    pkg = require(path.join(process.cwd(), 'package.json'));
-  } catch (e) {
-    return callback(new Error('Could not run local stdlib function, invalid package.json\n[!] Please make sure this directory contains a valid StdLib service'));
-  }
+  return new Promise((resolve, reject) => {
 
-  if (!pkg.stdlib) {
-    return callback(new Error('Could not run local stdlib function, no "stdlib" property set in package.json\n[!] Please make sure this directory contains a valid StdLib service'));
-  }
+    let hasCallback = typeof callback === 'function';
 
-  names = names.length === 1 && pkg.stdlib.defaultFunction ?
-    names.concat(pkg.stdlib.defaultFunction) :
-    names;
-  let pathname = path.join.apply(null, [process.cwd()].concat('f', names, 'index.js'));
-  let fnpathname = path.join.apply(null, [process.cwd()].concat('f', names, 'function.json'));
-  let fn;
-  let fndata;
-  let fnheaders;
-
-  try {
-    fn = require(pathname);
-    fndata = require(fnpathname) || {};
-    fnheaders = fndata.http && fndata.http.headers || {};
-  } catch (e) {
-    return callback(e);
-  }
-
-  if (typeof fn !== 'function') {
-    return callback(new Error(`${params.name}: No valid function exported from "${pathname}"`));
-  }
-
-  let fnParams = {args: args, kwargs: kwargs};
-  fnParams.buffer = body instanceof Buffer ? body : new Buffer(0);
-  fnParams.remoteAddress = '::1';
-  fnParams.service = '.';
-  fnParams.env = process.env.ENV || 'dev';
-  fnParams.keys = {};
-  fnParams.user = null;
-
-  fn(fnParams, (err, result, rheaders) => {
-
-    if (err) {
-      return callback(err);
+    try {
+      pkg = require(path.join(process.cwd(), 'package.json'));
+    } catch (e) {
+      let err = new Error('Could not run local stdlib function, invalid package.json\n[!] Please make sure this directory contains a valid StdLib service');
+      return hasCallback ? callback(err) : reject(err);
     }
 
-    let headers = {'content-type': result instanceof Buffer ? 'application/octet-stream' : 'application/json'};
-    rheaders = rheaders || {};
-    Object.keys(fnheaders)
-      .forEach(h => headers[h.toLowerCase()] = fnheaders[h]);
-    Object.keys(rheaders)
-      .forEach(h => headers[h.toLowerCase()] = rheaders[h]);
+    if (!pkg.stdlib) {
+      let err = new Error('Could not run local stdlib function, no "stdlib" property set in package.json\n[!] Please make sure this directory contains a valid StdLib service');
+      return hasCallback ? callback(err) : reject(err);
+    }
 
-    return callback(err, result, headers);
+    names = names.length === 1 && pkg.stdlib.defaultFunction ?
+      names.concat(pkg.stdlib.defaultFunction) :
+      names;
+    let pathname = path.join.apply(null, [process.cwd()].concat('f', names, 'index.js'));
+    let fnpathname = path.join.apply(null, [process.cwd()].concat('f', names, 'function.json'));
+    let fn;
+    let fndata;
+    let fnheaders;
+
+    try {
+      fn = require(pathname);
+      fndata = require(fnpathname) || {};
+      fnheaders = fndata.http && fndata.http.headers || {};
+    } catch (e) {
+      return hasCallback ? callback(e) : reject(e);
+    }
+
+    if (typeof fn !== 'function') {
+      let err = new Error(`${params.name}: No valid function exported from "${pathname}"`);
+      return hasCallback ? callback(err) : reject(err);
+    }
+
+    let fnParams = {args: args, kwargs: kwargs};
+    fnParams.buffer = body instanceof Buffer ? body : new Buffer(0);
+    fnParams.remoteAddress = '::1';
+    fnParams.service = '.';
+    fnParams.env = process.env.ENV || 'dev';
+    fnParams.keys = {};
+    fnParams.user = null;
+
+    fn(fnParams, (err, result, rheaders) => {
+
+      if (err) {
+        return hasCallback ? callback(err) : reject(err);
+      }
+
+      let headers = {'content-type': result instanceof Buffer ? 'application/octet-stream' : 'application/json'};
+      rheaders = rheaders || {};
+      Object.keys(fnheaders)
+        .forEach(h => headers[h.toLowerCase()] = fnheaders[h]);
+      Object.keys(rheaders)
+        .forEach(h => headers[h.toLowerCase()] = rheaders[h]);
+
+      return hasCallback ? callback(null, result, headers) : resolve(result);
+
+    });
 
   });
 

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -3,7 +3,7 @@ module.exports = (args) => {
   let kwargs = {};
   let body;
   let content;
-  let callback = typeof args[args.length - 1] === 'function' ? args.pop() : () => {};
+  let callback = typeof args[args.length - 1] === 'function' ? args.pop() : undefined;
 
   if ((args.length === 1 || args.length === 2) && args[0] instanceof Buffer) {
     body = args.shift();

--- a/lib/remote.js
+++ b/lib/remote.js
@@ -8,82 +8,88 @@ const KEYS = {};
 
 module.exports = (cfg, names, args, kwargs, body, callback) => {
 
-  cfg = cfg || {};
-  cfg.host = cfg.host || HOST;
-  cfg.port = cfg.port || PORT;
-  cfg.path = cfg.path || PATH;
-  cfg.keys = cfg.keys || KEYS;
-  cfg.debug = !!cfg.debug;
-  cfg.webhook = cfg.webhook || null;
+  return new Promise((resolve, reject) => {
 
-  let pathname = cfg.debug ?
-    names.slice(3).join('/') :
-    names.slice(0, 2).join('/') + names.slice(2).join('/');
-  let headers = {};
-  let responded = false;
+    cfg = cfg || {};
+    cfg.host = cfg.host || HOST;
+    cfg.port = cfg.port || PORT;
+    cfg.path = cfg.path || PATH;
+    cfg.keys = cfg.keys || KEYS;
+    cfg.debug = !!cfg.debug;
+    cfg.webhook = cfg.webhook || null;
 
-  if (body instanceof Buffer) {
-    headers['Content-Type'] = 'application/octet-stream';
-    pathname += '?' + Object.keys(kwargs).map(key => `${encodeURI(key)}=${encodeURI(kwargs[key])}`).join('&');
-  } else {
-    headers['Content-Type'] = 'application/json';
-    body = new Buffer(JSON.stringify(body));
-  }
+    let pathname = cfg.debug ?
+      names.slice(3).join('/') :
+      names.slice(0, 2).join('/') + names.slice(2).join('/');
+    let headers = {};
+    let responded = false;
+    let hasCallback = typeof callback === 'function';
 
-  if (cfg.token) {
-    headers['Authorization'] = `Bearer ${cfg.token}`;
-  }
+    if (body instanceof Buffer) {
+      headers['Content-Type'] = 'application/octet-stream';
+      pathname += '?' + Object.keys(kwargs).map(key => `${encodeURI(key)}=${encodeURI(kwargs[key])}`).join('&');
+    } else {
+      headers['Content-Type'] = 'application/json';
+      body = new Buffer(JSON.stringify(body));
+    }
 
-  if (cfg.webhook) {
-    headers['X-Webhook'] = cfg.webhook;
-  }
+    if (cfg.token) {
+      headers['Authorization'] = `Bearer ${cfg.token}`;
+    }
 
-  if (Object.keys(cfg.keys).length) {
-    headers['X-Authorization-Keys'] = JSON.stringify(cfg.keys);
-  }
+    if (cfg.webhook) {
+      headers['X-Webhook'] = cfg.webhook;
+    }
 
-  let req = (cfg.port === 443 ? https : http).request({
-    host: cfg.host,
-    method: 'POST',
-    headers: headers,
-    port: cfg.port,
-    path: `${cfg.path}${pathname}`,
-    agent: false
-  }, function (res) {
+    if (Object.keys(cfg.keys).length) {
+      headers['X-Authorization-Keys'] = JSON.stringify(cfg.keys);
+    }
 
-    let buffers = [];
+    let req = (cfg.port === 443 ? https : http).request({
+      host: cfg.host,
+      method: 'POST',
+      headers: headers,
+      port: cfg.port,
+      path: `${cfg.path}${pathname}`,
+      agent: false
+    }, function (res) {
 
-    res.on('data', chunk => buffers.push(chunk));
-    res.on('end', () => {
+      let buffers = [];
 
-      var response = Buffer.concat(buffers);
-      var contentType = res.headers['content-type'] || '';
+      res.on('data', chunk => buffers.push(chunk));
+      res.on('end', () => {
 
-      if (contentType === 'application/json') {
-        response = response.toString();
-        try {
-          response = JSON.parse(response);
-        } catch(e) {
-          response = null;
+        var response = Buffer.concat(buffers);
+        var contentType = res.headers['content-type'] || '';
+
+        if (contentType === 'application/json') {
+          response = response.toString();
+          try {
+            response = JSON.parse(response);
+          } catch(e) {
+            response = null;
+          }
+        } else if (contentType.match(/^text\/.*$/i)) {
+          response = response.toString();
         }
-      } else if (contentType.match(/^text\/.*$/i)) {
-        response = response.toString();
-      }
 
-      responded = true;
+        responded = true;
 
-      if (((res.statusCode / 100) | 0) !== 2) {
-        return callback(new Error(response));
-      } else {
-        return callback(null, response, res.headers);
-      }
+        if (((res.statusCode / 100) | 0) !== 2) {
+          let err = new Error(response);
+          return hasCallback ? callback(err) : reject(err);
+        } else {
+          return hasCallback ? callback(null, response, res.headers) : resolve(response);
+        }
+
+      });
 
     });
 
-  });
+    req.on('error', err => responded || hasCallback ? callback(err) : reject(err));
+    req.write(body);
+    req.end();
 
-  req.on('error', err => responded || callback(err));
-  req.write(body);
-  req.end();
+  });
 
 };


### PR DESCRIPTION
Closes #1.

* This change is most easily reviewed using Git's `-b` option to ignore whitespace.
* Our code styles differ but I tried to mimic yours as much as possible.
* As discussed in Slack, result headers are omitted from the Promise API. We could resolve the promise to an object containing both results and headers, but this would differ from the current callback usage and normalizing the two would mean a breaking change to callbacks.
* I didn't want to clutter up the README too much but still felt this needed documenting, so I added one simple example. Let me know if you prefer something else.