### PR TITLE
Remove unused "fs" require

### DIFF
--- a/lib/local.js
+++ b/lib/local.js
@@ -1,7 +1,6 @@
 // WARNING: Deprecated. Use "@local" identifier instead.
 
 const path = require('path');
-const fs = require('fs');
 
 const FUNCTION_PATH = 'functions';
 


### PR DESCRIPTION
The import is currently unused, so it can safely be removed.

It has also caused problems for us in an environment where we are unable to use the `fs` package.